### PR TITLE
Enable loading & deleting "bootonce.firm" from SD card

### DIFF
--- a/arm9_stage2/source/fs.c
+++ b/arm9_stage2/source/fs.c
@@ -68,3 +68,8 @@ bool fileWrite(const void *buffer, const char *path, u32 size)
             return false;
     }
 }
+
+bool fileDelete(const char* path)
+{
+    return (f_unlink(path) == FR_OK);
+}

--- a/arm9_stage2/source/fs.h
+++ b/arm9_stage2/source/fs.h
@@ -11,3 +11,4 @@ void unmountSd(void);
 bool mountCtrNand(void);
 u32 fileRead(void *dest, const char *path, u32 maxSize);
 bool fileWrite(const void *buffer, const char *path, u32 size);
+bool fileDelete(const char* path);

--- a/arm9_stage2/source/main.c
+++ b/arm9_stage2/source/main.c
@@ -26,6 +26,22 @@ static void initScreens(void)
     i2cWriteRegister(I2C_DEV_MCU, 0x22, 0x2A); //Turn on backlight
 }
 
+static void loadFirmOnce(void)
+{
+    if(fileRead(firm, "bootonce.firm", MAX_FIRM_SIZE) != 0)
+    {
+        if(checkFirm(firm))
+        {
+            const char *argv[1];
+            argv[0] = "sdmc:/bootonce.firm";
+            fileDelete("bootonce.firm");
+            
+            if(firm->reserved2[0] & 1) initScreens();
+            launchFirm(firm, 1, (char **)argv);
+        }
+    }
+}
+
 static void loadFirm(bool isNand)
 {
     if(fileRead(firm, "boot.firm", MAX_FIRM_SIZE) != 0)
@@ -55,6 +71,7 @@ void main(void)
             fileWrite((void *)0x10012000, "boot9strap/otp.bin", 0x100);
         }
 
+        loadFirmOnce();
         loadFirm(false);
         unmountSd();
     }


### PR DESCRIPTION
This is useful for FIRM loaders from userland, for example (which is the reason behind this pull request for me) A9NC or for @Ord1m3n's A9SP (ARM9 shortcut project).

You may not want this in there, which I'd understand, cause trying to locate another file may be detrimental on boot times. However, you could just disable the define, as you see nothing else in the code is changed. I'm also open to changing this pull request any way you want it, and you can of course not take it at all with no offense taken on my side.

However, keeping this in here, even in disabled state, would be pretty helpful to me and maybe others, too, as I would not require patches in future releases and could just reenable the define.