### PR TITLE
Markdown Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Launches "boot.firm" off of the SD card or CTRNAND. Hold Start + Select + X on b
 
 **Credits:**
 
-[Normmatt](https://github.com/Normmatt): Theorizing the NDMA overwite exploit.
-[TuxSH](https://github.com/TuxSH): Help implementing bootrom payloads.
-[Luma3DS](https://github.com/AuroraWright/Luma3DS): Codebase used in the stage 2 arm9 payload loader.
+[Normmatt](https://github.com/Normmatt): Theorizing the NDMA overwite exploit.    
+[TuxSH](https://github.com/TuxSH): Help implementing bootrom payloads.    
+[Luma3DS](https://github.com/AuroraWright/Luma3DS): Codebase used in the stage 2 arm9 payload loader.    
 
 **Licensing:**
 


### PR DESCRIPTION
Markdown requires 4 spaces at the end of a line to do a line break.