### PR TITLE
Allow loading & deleting "bootonce.firm" if it exists

### DIFF
--- a/stage2/arm9/source/fs.c
+++ b/stage2/arm9/source/fs.c
@@ -68,3 +68,8 @@ bool fileWrite(const void *buffer, const char *path, u32 size)
             return false;
     }
 }
+
+bool fileDelete(const char* path)
+{
+    return (f_unlink(path) == FR_OK);
+}

--- a/stage2/arm9/source/fs.h
+++ b/stage2/arm9/source/fs.h
@@ -11,3 +11,4 @@ void unmountSd(void);
 bool mountCtrNand(void);
 u32 fileRead(void *dest, const char *path, u32 size, u32 maxSize);
 bool fileWrite(const void *buffer, const char *path, u32 size);
+bool fileDelete(const char* path);


### PR DESCRIPTION
Checks for "bootonce.firm" on SD card, loads & deletes if available.