### PR TITLE
Boot order preference via sd:/boot_order.txt

### DIFF
--- a/stage2/arm9/source/fs.h
+++ b/stage2/arm9/source/fs.h
@@ -12,3 +12,5 @@ bool mountCtrNand(void);
 void unmountCtrNand(void);
 u32 fileRead(void *dest, const char *path, u32 size, u32 maxSize);
 bool fileWrite(const void *buffer, const char *path, u32 size);
+bool fileExists(const char* path);
+u32 fileReadLine(char *dest, const char *path, u32 lineNum, u32 maxSize);

--- a/stage2/arm9/source/main.c
+++ b/stage2/arm9/source/main.c
@@ -33,9 +33,38 @@ static void invokeArm11Function(Arm11Operation op)
     while(*operation != ARM11_READY); 
 }
 
+const char *getFirmNameFromBootOrder(void) 
+{
+    const char* bootOrder = NULL;
+    if (fileExists("boot_order.txt"))
+        bootOrder = "boot_order.txt";
+    else if (fileExists("bootorder.txt"))
+        bootOrder = "bootorder.txt";
+    
+    if (bootOrder)
+    {
+        static char line[2048];
+        u32 lineNumber = 0;
+        u32 bytesRead;
+
+        while ((bytesRead = fileReadLine(line, bootOrder, lineNumber, sizeof(line))) > 0)
+        {
+            line[bytesRead] = '\0';
+
+            if (fileExists(line))
+                return line;
+
+            lineNumber++;
+        }
+    }
+
+    return "boot.firm";
+}
+
 static FirmLoadStatus loadFirm(Firm **outFirm)
 {
-    static const char *firmName = "boot.firm";
+    const char *firmName = getFirmNameFromBootOrder();
+
     Firm *firmHeader = (Firm *)0x080A0000;
     u32 rd = fileRead(firmHeader, firmName, 0x200, 0);
     if (rd != 0x200)


### PR DESCRIPTION
Directly addresses / resolves #38 

With this PR proposal, anyone can override the firmware to be booted by B9S.

By default, it will always boot sd:/boot.firm.

But by creating a sd:/boot_order.txt file, you can specify a list of firmwares to be loaded and the first one that is available is going to be selected for loading.

For example, your sd:/boot_order.txt file could look like:
```
bax.firm
bax/bax.firm
dev.firm
```

This list acts just like your PCs BIOS: first one in order available gets booted, all the others are skipped.

And of course, if none are available, B9S will always boot the boot.firm firmware so it does not affect its standard behavior. 

Note: currently there is no integrity check being made in the process, which means that if the file you are pointing exists on the SD card and is not a valid firmware, the console will NOT boot to boot.firm file in fallback (you will encounter the notification LED status informing that the boot has failed, and B9S will try to boot from CTRNAND as usual for a corrupted firmware).